### PR TITLE
Fixes broken link to submit a pull request.

### DIFF
--- a/contribute.html
+++ b/contribute.html
@@ -40,7 +40,7 @@
           <p>If you'd like to help improve Slim, clone the project with <a href="http://git-scm.com">Git</a>
             by running:</p>
             <pre><code>$ git clone git://github.com/slim-template/slim</pre></code>
-            <p>Work your magic and then <a href="http://help.github.com/pull-requests/">submit a pull request</a>.  We love pull requests!</p>
+            <p>Work your magic and then <a href="https://github.com/slim-template/slim/pulls">submit a pull request</a>.  We love pull requests!</p>
             <p><strong>Please remember to test against Ruby versions 2.0.0, 1.9.2 and 1.8.7.</strong></p>
           </p>
           <hr/>


### PR DESCRIPTION
Previously the link for submitting a pull request was to a page on github which no longer exists. 

This has now been replaced with a link to the pull requests page for the slim gem in the same fashion as the issues link.